### PR TITLE
(DRAFT) test(delete): initialize unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 *.sig
 
 pkg/
-src/
+
 
 ### Git ###
 # Created by git for backups. To disable backups in Git:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod cli;
+pub mod operations;
+pub mod utils;
+include!(concat!(env!("OUT_DIR"), "/domain.rs"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,8 @@
-mod cli;
-mod operations;
-mod utils;
 
-use crate::cli::parser::CliArgs;
-use crate::operations::delete::delete;
-use crate::operations::upload::upload;
+use NexusCLI::cli::parser::CliArgs;
+use NexusCLI::operations::delete::delete;
+use NexusCLI::operations::upload::upload;
 use clap::Parser;
-
-include!(concat!(env!("OUT_DIR"), "/domain.rs"));
 
 fn main() {
     let args = CliArgs::parse();

--- a/tests/delete_test.rs
+++ b/tests/delete_test.rs
@@ -1,0 +1,22 @@
+use std::collections::HashMap;
+use NexusCLI::cli::parser::CliArgs;
+use NexusCLI::operations::delete::delete;
+
+
+#[test]
+fn test_delete_function() {
+    let args = CliArgs {
+        operation: "D".to_string(),
+        repository: Some("test-repo".to_string()),
+        directory: Some("test-dir".to_string()),
+        source: None,
+    };
+
+    let mock_curl = |_: &str, _: &str, _: HashMap<&str, &String>, _: Option<&str>| -> Result<(), curl::Error> {
+        Ok(())
+    };
+
+
+    delete(args);
+    assert_eq!(1, 1);
+}


### PR DESCRIPTION
This commit adds the initial code for NexusCLI. It includes the following changes:

- Updated `.gitignore` to remove `src/` directory
- Added `src/lib.rs` file with module imports and domain include
- Refactored `src/main.rs` to use crate name and updated imports
- Added `tests/delete_test.rs` with a test for the delete function

These changes lay the foundation for further development of NexusCLI.