### PR TITLE
(DRAFT) Chore: Improve error handling and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 *.sig
 
 pkg/
-src/
 
 ### Git ###
 # Created by git for backups. To disable backups in Git:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,3 @@ build = "build.rs"
 clap = { version = "4.4.6", features = ["derive"] }
 curl = "0.4.44"
 cli-clipboard = "0.4.0"
-
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "NexusCLI"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/operations/upload.rs
+++ b/src/operations/upload.rs
@@ -1,31 +1,52 @@
 use crate::cli::parser::CliArgs;
-use crate::utils::network_utils::execute_curl_request;
+use curl::easy::{Easy, ReadError};
+use std::fs::File;
+use std::io::Read;
 use crate::DOMAIN;
 use crate::PROXY;
-use cli_clipboard;
-use std::collections::HashMap;
 use std::process::exit;
 
 pub fn upload(args: CliArgs) {
     let repository: &str = args.repository.as_ref().unwrap();
     let directory = args.directory.as_ref().unwrap();
-    let url = format!("{}/repository/{}/{}", DOMAIN, repository, directory,);
+    let url = format!("{}/repository/{}/{}", DOMAIN, repository, directory);
 
-    let mut curl_args = HashMap::new();
-    let source_file = args.source.as_ref().unwrap();
-    curl_args.insert("upload-file", source_file);
-
-    println!(
-        "Voulez-vous éxecuter la commande POST curl avec l'url : {}",
-        url
-    );
+    println!("Voulez-vous éxecuter la commande UPLOAD curl avec l'url : {}", url);
     println!("O/N");
     let mut input = String::new();
     std::io::stdin().read_line(&mut input).unwrap();
-    if input.trim().to_uppercase() == "O".to_uppercase() {
-        match execute_curl_request(&url, "PUT", curl_args, PROXY) {
-            Ok(_) => println!("Requête réussie"),
-            Err(e) => println!("Erreur lors de la requête : {}", e),
+
+    if input.trim().to_uppercase() == "O" {
+        let source_file = args.source.expect("Le chemin du fichier source est nécessaire");
+
+        let mut easy = Easy::new();
+        easy.url(&url).expect("Erreur lors de la définition de l'URL");
+        easy.upload(true).expect("Erreur lors de la mise en mode upload");
+        if let Some(proxy) = PROXY {
+            easy.proxy(proxy).expect("Erreur lors de la définition du proxy");
+            easy.noproxy("insee.fr").expect("Erreur lors de la définition de noproxy");
+        }
+
+        let mut file = File::open(&source_file).expect("Le fichier n'a pas pu être ouvert");
+        let mut file_contents = Vec::new();
+        file.read_to_end(&mut file_contents).expect("Échec de la lecture du fichier");
+
+        easy.read_function(move |buf| -> Result<usize, ReadError> {
+            let mut slice = &file_contents[..];
+            match slice.read(buf) {
+                Ok(size) => Ok(size),
+                Err(_) => Err(ReadError::Abort),
+            }
+        }).expect("Erreur lors de la définition de la fonction de lecture");
+        match easy.perform() {
+            Ok(_) => {
+                if easy.response_code().expect("Erreur lors de la récupération du code de réponse") >= 300 {
+                    panic!("Erreur lors de la requête : {}", easy.response_code().unwrap());
+                }
+                println!("Requête réussie");
+            }
+
+            Err(e) => println!("Erreur lors de la requête HTTP CODE ({}) ", e),
         }
     } else {
         println!("Commande abordée, mais la commande a été copiée dans le presse-papier");
@@ -35,8 +56,8 @@ pub fn upload(args: CliArgs) {
             "".to_string()
         };
 
-        let command = format!("curl{} -k --upload-file {} {}", proxy, source_file, url);
-        cli_clipboard::set_contents(command.to_owned()).unwrap();
+        let command = format!("curl{} -k --upload-file {} {}", proxy, &args.source.unwrap(), url);
+        cli_clipboard::set_contents(command).expect("Échec de la copie dans le presse-papier");
     }
 
     exit(0);

--- a/src/operations/upload.rs
+++ b/src/operations/upload.rs
@@ -1,37 +1,52 @@
 use crate::cli::parser::CliArgs;
-use curl::easy::{Easy};
+use crate::utils::easy_utils::read_file;
 use crate::DOMAIN;
 use crate::PROXY;
+use curl::easy::Easy;
 use std::process::exit;
-use crate::utils::easy_utils::read_file;
 
 pub fn upload(args: CliArgs) {
     let repository: &str = args.repository.as_ref().unwrap();
     let directory = args.directory.as_ref().unwrap();
     let url = format!("{}/repository/{}/{}", DOMAIN, repository, directory);
 
-    println!("Voulez-vous éxecuter la commande UPLOAD curl avec l'url : {}", url);
+    println!(
+        "Voulez-vous éxecuter la commande UPLOAD curl avec l'url : {}",
+        url
+    );
     println!("O/N");
     let mut input = String::new();
     std::io::stdin().read_line(&mut input).unwrap();
 
     if input.trim().to_uppercase() == "O" {
-        let source_file = args.source.expect("Le chemin du fichier source est nécessaire");
+        let source_file = args
+            .source
+            .expect("Le chemin du fichier source est nécessaire");
 
         let mut easy = Easy::new();
-        easy.url(&url).expect("Erreur lors de la définition de l'URL");
-        easy.upload(true).expect("Erreur lors de la mise en mode upload");
+        easy.url(&url)
+            .expect("Erreur lors de la définition de l'URL");
+        easy.upload(true)
+            .expect("Erreur lors de la mise en mode upload");
         if let Some(proxy) = PROXY {
-            easy.proxy(proxy).expect("Erreur lors de la définition du proxy");
-            easy.noproxy("insee.fr").expect("Erreur lors de la définition de noproxy");
+            easy.proxy(proxy)
+                .expect("Erreur lors de la définition du proxy");
+            easy.noproxy("insee.fr")
+                .expect("Erreur lors de la définition de noproxy");
         }
-
 
         read_file(&source_file).expect("Erreur lors de la définition de la fonction de lecture");
         match easy.perform() {
             Ok(_) => {
-                if easy.response_code().expect("Erreur lors de la récupération du code de réponse") >= 300 {
-                    panic!("Erreur lors de la requête : {}", easy.response_code().unwrap());
+                if easy
+                    .response_code()
+                    .expect("Erreur lors de la récupération du code de réponse")
+                    >= 300
+                {
+                    panic!(
+                        "Erreur lors de la requête : {}",
+                        easy.response_code().unwrap()
+                    );
                 }
                 println!("Requête réussie");
             }
@@ -46,7 +61,12 @@ pub fn upload(args: CliArgs) {
             "".to_string()
         };
 
-        let command = format!("curl{} -k --upload-file {} {}", proxy, &args.source.unwrap(), url);
+        let command = format!(
+            "curl{} -k --upload-file {} {}",
+            proxy,
+            &args.source.unwrap(),
+            url
+        );
         cli_clipboard::set_contents(command).expect("Échec de la copie dans le presse-papier");
     }
 

--- a/src/operations/upload.rs
+++ b/src/operations/upload.rs
@@ -1,10 +1,9 @@
 use crate::cli::parser::CliArgs;
-use curl::easy::{Easy, ReadError};
-use std::fs::File;
-use std::io::Read;
+use curl::easy::{Easy};
 use crate::DOMAIN;
 use crate::PROXY;
 use std::process::exit;
+use crate::utils::easy_utils::read_file;
 
 pub fn upload(args: CliArgs) {
     let repository: &str = args.repository.as_ref().unwrap();
@@ -27,17 +26,8 @@ pub fn upload(args: CliArgs) {
             easy.noproxy("insee.fr").expect("Erreur lors de la définition de noproxy");
         }
 
-        let mut file = File::open(&source_file).expect("Le fichier n'a pas pu être ouvert");
-        let mut file_contents = Vec::new();
-        file.read_to_end(&mut file_contents).expect("Échec de la lecture du fichier");
 
-        easy.read_function(move |buf| -> Result<usize, ReadError> {
-            let mut slice = &file_contents[..];
-            match slice.read(buf) {
-                Ok(size) => Ok(size),
-                Err(_) => Err(ReadError::Abort),
-            }
-        }).expect("Erreur lors de la définition de la fonction de lecture");
+        read_file(&source_file).expect("Erreur lors de la définition de la fonction de lecture");
         match easy.perform() {
             Ok(_) => {
                 if easy.response_code().expect("Erreur lors de la récupération du code de réponse") >= 300 {

--- a/src/operations/upload.rs
+++ b/src/operations/upload.rs
@@ -23,7 +23,7 @@ pub fn upload(args: CliArgs) {
     let mut input = String::new();
     std::io::stdin().read_line(&mut input).unwrap();
     if input.trim().to_uppercase() == "O".to_uppercase() {
-        match execute_curl_request(&url, "POST", curl_args, PROXY) {
+        match execute_curl_request(&url, "PUT", curl_args, PROXY) {
             Ok(_) => println!("Requête réussie"),
             Err(e) => println!("Erreur lors de la requête : {}", e),
         }

--- a/src/utils/easy_utils.rs
+++ b/src/utils/easy_utils.rs
@@ -1,14 +1,14 @@
-use std::fs::File;
-use std::io::Read;
 use curl::easy::{Easy, ReadError};
 use curl::Error;
+use std::fs::File;
+use std::io::Read;
 
 pub fn read_file(file_path: &str) -> Result<(), Error> {
     let mut easy = Easy::new();
     let mut file = File::open(&file_path).expect("Le fichier n'a pas pu être ouvert");
     let mut file_contents = Vec::new();
-    file.read_to_end(&mut file_contents).expect("Échec de la lecture du fichier");
-
+    file.read_to_end(&mut file_contents)
+        .expect("Échec de la lecture du fichier");
 
     easy.read_function(move |buf| -> Result<usize, ReadError> {
         let mut slice = &file_contents[..];

--- a/src/utils/easy_utils.rs
+++ b/src/utils/easy_utils.rs
@@ -1,0 +1,20 @@
+use std::fs::File;
+use std::io::Read;
+use curl::easy::{Easy, ReadError};
+use curl::Error;
+
+pub fn read_file(file_path: &str) -> Result<(), Error> {
+    let mut easy = Easy::new();
+    let mut file = File::open(&file_path).expect("Le fichier n'a pas pu être ouvert");
+    let mut file_contents = Vec::new();
+    file.read_to_end(&mut file_contents).expect("Échec de la lecture du fichier");
+
+
+    easy.read_function(move |buf| -> Result<usize, ReadError> {
+        let mut slice = &file_contents[..];
+        match slice.read(buf) {
+            Ok(size) => Ok(size),
+            Err(_) => Err(ReadError::Abort),
+        }
+    })
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod network_utils;
+pub mod easy_utils;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,2 @@
-pub mod network_utils;
 pub mod easy_utils;
+pub mod network_utils;

--- a/src/utils/network_utils.rs
+++ b/src/utils/network_utils.rs
@@ -1,8 +1,8 @@
-use curl::easy::{Easy};
+use crate::utils::easy_utils::read_file;
+use curl::easy::Easy;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
-use crate::utils::easy_utils::read_file;
 
 pub fn execute_curl_request(
     url: &str,

--- a/src/utils/network_utils.rs
+++ b/src/utils/network_utils.rs
@@ -1,7 +1,8 @@
-use curl::easy::{Easy, ReadError};
+use curl::easy::{Easy};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
+use crate::utils::easy_utils::read_file;
 
 pub fn execute_curl_request(
     url: &str,
@@ -24,14 +25,7 @@ pub fn execute_curl_request(
         let mut file_contents = Vec::new();
         file.read_to_end(&mut file_contents)
             .expect("Échec de la lecture du fichier");
-        let file_contents = file_contents;
-        easy.read_function(move |buf| -> Result<usize, ReadError> {
-            let mut slice = &file_contents[..];
-            match slice.read(buf) {
-                Ok(size) => Ok(size),
-                Err(_) => Err(ReadError::Abort),
-            }
-        })?;
+        read_file(filepath).expect("Erreur lors de la définition de la fonction de lecture");
     }
 
     easy.verbose(true)?;

--- a/src/utils/network_utils.rs
+++ b/src/utils/network_utils.rs
@@ -22,7 +22,8 @@ pub fn execute_curl_request(
 
         let mut file = File::open(filepath).expect("Le fichier n'a pas pu être ouvert");
         let mut file_contents = Vec::new();
-        file.read_to_end(&mut file_contents).expect("Échec de la lecture du fichier");
+        file.read_to_end(&mut file_contents)
+            .expect("Échec de la lecture du fichier");
         let file_contents = file_contents;
         easy.read_function(move |buf| -> Result<usize, ReadError> {
             let mut slice = &file_contents[..];
@@ -37,7 +38,9 @@ pub fn execute_curl_request(
     match easy.perform() {
         Ok(_) => {
             let mut response_code = 0;
-            easy.response_code().map(|code| response_code = code).unwrap();
+            easy.response_code()
+                .map(|code| response_code = code)
+                .unwrap();
             if response_code >= 400 {
                 println!("Erreur lors de la requête : {}", response_code);
             }
@@ -47,6 +50,4 @@ pub fn execute_curl_request(
         }
         Err(e) => Err(e),
     }
-
-
 }

--- a/src/utils/network_utils.rs
+++ b/src/utils/network_utils.rs
@@ -38,7 +38,18 @@ pub fn execute_curl_request(
     }
 
     match easy.perform() {
-        Ok(_) => Ok(()),
+        Ok(_) => {
+            let mut response_code = 0;
+            easy.response_code().map(|code| response_code = code).unwrap();
+            if response_code >= 400 {
+                println!("Erreur lors de la requête : {}", response_code);
+            }
+            println!("{}", response_code);
+
+            Ok(())
+        }
         Err(e) => Err(e),
     }
+
+
 }


### PR DESCRIPTION
This commit adds better error handling and logging to the execute_curl_request function in network_utils.rs. Now, if the response code is greater than or equal to 400, an error message will be printed. Additionally, the response code itself will also be printed for debugging purposes.